### PR TITLE
docs: add uportal supporting subscription model documentation

### DIFF
--- a/support/uportal-supporting-subscription-model.md
+++ b/support/uportal-supporting-subscription-model.md
@@ -1,0 +1,35 @@
+# uPortal Supporting Subscription Model
+
+The new Apereo membership model consists of two elements. The first is a Core Foundation Subscription, paid by all members. This covers key services Apereo provides for all its software communities – technical infrastructure, legal and licensing support, community coordination, events, and outreach. The second is a Supporting Subscription for specific Apereo Projects. This is an important way that organizations can substantively and collectively support projects they use and depend on. External to Apereo, organizations may also subscribe to commercial support offerings which address local support and targeted development. All three of these mechanisms address different but important needs.
+
+The uPortal Steering Committee is responsible for determining how subscription funds will be used. Possible ideas include hiring resources to help with: 
+
+* Coordination and engineering of releases
+* Testing
+* Bug fixing
+* Fit and finish of code and documentation pull requests
+* Welcoming and bootstrapping new developers and community participants
+
+The uPortal Steering Committee has developed a tiered rate for uPortal Supporting Subscriptions that gives institutions flexibility to determine what level of financial support they would like to demonstrate for uPortal. Supporting subscriptions are annual, on top of the standard Apereo Member/Affiliate rates.
+uPortal Supporting Subscription Rates:
+
+* $1,000 bronze, uPortal Friend
+* $5,000 silver, uPortal Booster
+* $10,000 gold, uPortal Sustainer
+* $20,000 platinum, uPortal Champion
+
+All uPortal Supporting Subscribers are entitled to:
+
+* Specifying a local uPortal Supporting Subscriber contact
+* Vote for a uPortal Supporting Subscriber representative on the uPortal Steering Committee 
+* Advance notice of uPortal security patches
+* Being recognized as a uPortal Supporting Subscriber on the project web site
+* The gratitude from the uPortal Community for their valuable support
+
+By becoming a uPortal Supporting Subscriber, you can help support continued improvements to the uPortal project such as releases that are more frequent, more complete, more stable, and better documented. Your support also helps make possible additional contributions from the community as potential contributors feel more welcome and encouraged. By coming together as a community through uPortal Supporting Subscriptions we can collectively ensure that uPortal better meets the needs of higher education organizations and beyond. We encourage you to consider becoming an Apereo Member/Affiliate organization and a uPortal Supporting Subscriber.
+
+Current uPortal Supporting Subscribers:
+
+* University of Wisconsin-Madison - uPortal Champion
+* Oakland University - uPortal Booster
+* Brigham Young University - uPortal Friend 


### PR DESCRIPTION
This is the first of many documents that will move off the apereo website. Moving it now allows us to create a longer lasting URL reference.