### PR TITLE
docs(release): migrate Maven release guide to Central Publisher Portal

### DIFF
--- a/manuals/en/uportal5-manual/developer/maven-release-process.md
+++ b/manuals/en/uportal5-manual/developer/maven-release-process.md
@@ -4,26 +4,37 @@
 
 There are 3 prerequisites to cutting maven releases:
 
-1.  [JIRA Account at Sonatype](https://issues.sonatype.org/secure/Signup!default.jspa)
+1.  [Sonatype Account at Central Publisher Portal](https://central.sonatype.com/)
+    -   NOTE!! Do not link a social account — create a local account.
+    -   See the first part of [Register to Publish Via the Central Portal](https://central.sonatype.org/register/central-portal/).
+    -   **Note:** The legacy OSSRH service (`oss.sonatype.org`) and the Sonatype JIRA signup were sunset in June 2025. All publishing — and all namespace-permissions requests — now go through the Central Publisher Portal.
 2.  Permissions at Sonatype to release projects
-    -   This is granted via a Jira ticket from a uPortal committer
+    -   Namespace permissions are managed via the [Central Publisher Portal](https://central.sonatype.com/).
+    -   If you need access to the `org.jasig.portlet` (or another uPortal ecosystem) namespace, contact a uPortal committer.
+    -   Expect approval to take a few days to complete.
 3.  [Set up public PGP key on a server](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
     -   Generate a key pair `gpg2 --gen-key`
     -   If you choose to have an expiration date, edit the key via `gpg2 --edit-key {key ID}`
     -   Determine the key ID and keyring file `gpg2 --list-keys` (the key ID is the `pub` ID)
-    -   Distribute your public key `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys {key ID}`
+    -   Distribute your public key `gpg2 --keyserver hkp://keyserver.ubuntu.com --send-keys {key ID}`
+        -   The `pool.sks-keyservers.net` pool was decommissioned in 2021 — do not use it.
 
 ## Setup
 
 Export your secret keyring via `gpg2 --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg`
 
-Create a Sonatype user token via <https://oss.sonatype.org> > Profile > User Tokens
+Create a Central Publisher Portal user token via <https://central.sonatype.com> > Profile > Generate User Token. Tokens are required — login password auth is not supported.
 
-In `$HOME/.m2/settings.xml`, configure Maven with your Sonatype user token:
+In `$HOME/.m2/settings.xml`, configure Maven with your Central Portal user token. The server `<id>` must match the `<distributionManagement>` repository id used by the component you are releasing. For components that still inherit the legacy `<id>sonatype-nexus-staging</id>` (e.g. older portlets), include that id too; for projects migrated to the Central Portal, use `<id>central</id>`:
 
 ```xml
 <settings>
     <servers>
+        <server>
+            <id>central</id>
+            <username>user_token_name</username>
+            <password>user_token_pw</password>
+        </server>
         <server>
             <id>sonatype-nexus-staging</id>
             <username>user_token_name</username>
@@ -35,11 +46,35 @@ In `$HOME/.m2/settings.xml`, configure Maven with your Sonatype user token:
 
 Setup is only required to be done once.
 
+### Verify distribution URLs before every release
+
+The legacy OSSRH host `oss.sonatype.org` was sunset in June 2025. Every `<distributionManagement>` URL in the component's POMs — and any inherited from parent POMs (notably `uportal-portlet-parent` and `org.sonatype.oss:oss-parent`) — must point at the Central Portal's OSSRH Staging API compatibility service.
+
+**Required URLs:**
+
+-   Release: `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/`
+-   Snapshot: `https://central.sonatype.com/repository/maven-snapshots/`
+
+**Audit before releasing** (from the component root):
+
+```sh
+grep -RIn --include=pom.xml -E 'oss\.sonatype\.org|sonatype-nexus-staging' .
+```
+
+If any stale OSSRH URLs appear, override them with a `<distributionManagement>` block in the component's top-level `pom.xml` so the inherited values are shadowed. Long-term, release an updated parent POM with the new URLs so every descendant picks them up automatically.
+
 ## Which Repo?
 
 We encourage performing releases directly from a clone of the official repository rather than a fork to avoid extra steps.
 
 This means when testing on `uPortal-start` for the release, you should use the `apereo` repository but configure the version of the component (eg the Bookmarks or Announcements portlet) to be the `SNAPSHOT` version that you'll build in the following steps.
+
+## Send Pre-Release Notice to Community
+
+For any non-snapshot release, email a notice to [`uportal-dev`](https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev) a couple of working days prior to cutting the release.
+
+-   Request any in-progress Pull Requests be merged by a certain date/time.
+-   Request deployers test the tip of `master`.
 
 ## Testing
 
@@ -97,17 +132,45 @@ $ mvn release:clean release:prepare release:perform
 
 :Note: During the `release` tasks, you will be prompted for a release version (e.g. `3.5.1`), release tag, and new development version.  Press `Enter` for the defaults.  The release process will then create two commits - a commit to set the new version (`3.5.1`), and a commit to set the version to the new snapshot (`3.5.2-SNAPSHOT`)
 
-## Close and Release from Nexus Staging Repository
+## Verify and Publish from Central Publisher Portal
 
-Close the release in Sonatype to ensure the pushed Maven artifacts pass checks:
-1.  Log into <https://oss.sonatype.org>
-2.  Search among `Build Promotion` > `Staging Repositories` for your username
-3.  Review the release for the expected artifacts
-4.  Select the uPortal artifact you staged and hit "Close"
-    -   The lifecycle is `Open --> Closed --> Released`
-5.  Wait a few minutes for the component's artifact to close
-6.  Release the artifact, and put the tag name in the description
-    -   Leave 'Automatically Drop' checked.
+Because Maven's `deploy` phase uses the legacy Nexus 2-flavored upload path, the OSSRH Staging API does **not** automatically close the staging repository after `release:perform` uploads the artifacts. You must manually trigger the upload into the Central Portal and then publish from the portal UI.
+
+### Push staged artifacts to the portal
+
+Run the following from the **same machine** that ran `release:perform` — the Central Portal matches staging repositories by source IP:
+
+```sh
+$ curl -X POST \
+    "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/{groupId}" \
+    -H "Authorization: Bearer $(echo -n '{username}:{password}' | base64)"
+```
+
+Replace `{groupId}` with the component's root namespace (e.g. `org.jasig.portlet`, `org.jasig.resourceserver`) and `{username}`/`{password}` with your Central Portal user token credentials (the same ones in `~/.m2/settings.xml`).
+
+If the deployment does not appear in the portal UI, search for open staging repositories:
+
+```sh
+$ curl -X GET \
+    "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id={groupId}" \
+    -H "Authorization: Bearer $(echo -n '{username}:{password}' | base64)"
+```
+
+### Review and publish
+
+1.  Log into <https://central.sonatype.com>
+2.  Navigate to **Deployments** — the staged artifacts should now be visible.
+3.  Review the release for the expected artifacts (parent POM + every submodule, including any WAR modules).
+4.  Verify the artifacts pass validation checks (signatures, POM requirements, matching `<packaging>` — see below).
+5.  Publish the deployment to make it available on Maven Central.
+
+### A note on POM packaging
+
+Central Portal validation rejects deployments where the advertised `<packaging>` does not match the uploaded artifact's file extension. This bit uPortal during the 2026 release: a Gradle `uploadArchives` block hardcoded `packaging 'jar'` for all subprojects, which broke the WAR module. In Maven, `<packaging>` is authoritative per-module, so the bug does not occur the same way — but confirm each module declares the right packaging:
+
+```sh
+$ grep -l '<packaging>war</packaging>' $(find . -name pom.xml -not -path '*/target/*')
+```
 
 ## Create Release Notes
 
@@ -146,6 +209,7 @@ $ docker push apereo/uportal-demo:latest
 ```
 
 ## Update Community
+
 For any non-snapshot release, email an announcement to [`uportal-dev`](https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev) and [`uportal-user`](https://groups.google.com/a/apereo.org/forum/#!forum/uportal-user).
 
 -   Be sure to acknowledge those who contributed to the release.
@@ -155,7 +219,9 @@ Have someone with access to the [uPortal Twitter account](https://twitter.com/up
 
 ## References
 
-(<https://apereo.atlassian.net/wiki/spaces/UPC/pages/102336655/Cutting+a+uPortal+Release>)
-(<https://central.sonatype.org/pages/ossrh-guide.html>)
-(<https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials>)
+-   <https://apereo.atlassian.net/wiki/spaces/UPC/pages/102336655/Cutting+a+uPortal+Release>
+-   <https://central.sonatype.org/publish/publish-portal-guide/>
+-   <https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/>
+-   <https://maven.apache.org/maven-release/maven-release-plugin/>
+-   <https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials>
 

--- a/manuals/en/uportal5-manual/developer/maven-release-process.md
+++ b/manuals/en/uportal5-manual/developer/maven-release-process.md
@@ -7,7 +7,7 @@ There are 3 prerequisites to cutting maven releases:
 1.  [Sonatype Account at Central Publisher Portal](https://central.sonatype.com/)
     -   NOTE!! Do not link a social account — create a local account.
     -   See the first part of [Register to Publish Via the Central Portal](https://central.sonatype.org/register/central-portal/).
-    -   **Note:** The legacy OSSRH service (`oss.sonatype.org`) and the Sonatype JIRA signup were sunset in June 2025. All publishing — and all namespace-permissions requests — now go through the Central Publisher Portal.
+    -   **Note:** The legacy OSSRH service (`oss.sonatype.org`) and the Sonatype JIRA account-creation flow were sunset in June 2025. All publishing — and all namespace-permissions requests — now go through the Central Publisher Portal.
 2.  Permissions at Sonatype to release projects
     -   Namespace permissions are managed via the [Central Publisher Portal](https://central.sonatype.com/).
     -   If you need access to the `org.jasig.portlet` (or another uPortal ecosystem) namespace, contact a uPortal committer.
@@ -166,7 +166,7 @@ $ curl -X GET \
 
 ### A note on POM packaging
 
-Central Portal validation rejects deployments where the advertised `<packaging>` does not match the uploaded artifact's file extension. This bit uPortal during the 2026 release: a Gradle `uploadArchives` block hardcoded `packaging 'jar'` for all subprojects, which broke the WAR module. In Maven, `<packaging>` is authoritative per-module, so the bug does not occur the same way — but confirm each module declares the right packaging:
+Central Portal validation rejects deployments where the advertised `<packaging>` does not match the uploaded artifact's file extension. This bit uPortal during the 2026 release: a Gradle `uploadArchives` block hardcoded `packaging 'jar'` for every submodule, which broke the WAR module. In Maven, `<packaging>` is authoritative per-module, so the bug does not occur the same way — but confirm each module declares the right packaging:
 
 ```sh
 $ grep -l '<packaging>war</packaging>' $(find . -name pom.xml -not -path '*/target/*')


### PR DESCRIPTION
## Summary

- OSSRH (oss.sonatype.org) was sunset June 2025. Update the Maven release guide for the Central Publisher Portal flow end-to-end, folding in the learnings from the recent uPortal 5.x release.
- Rewrite the Nexus staging section as a Central Portal verify/publish section with the manual \`curl POST\` upload step (same-IP requirement) and UI review flow.
- Add a distribution-URLs audit step, a POM-packaging note (WAR module validation), and refresh PGP keyserver + reference links.

## Changes to \`manuals/en/uportal5-manual/developer/maven-release-process.md\`

- **Prerequisites**: Sonatype JIRA signup → Central Publisher Portal account; namespace-permissions flow updated; keyserver \`pool.sks-keyservers.net\` (decommissioned 2021) → \`keyserver.ubuntu.com\`.
- **Setup**: Token creation via central.sonatype.com; \`settings.xml\` shows both \`central\` and \`sonatype-nexus-staging\` server ids so in-flight ecosystem POMs still work.
- **New: Verify distribution URLs before every release** — lists the required Central Portal URLs, provides an audit \`grep\`, and explains how to shadow inherited OSSRH URLs from \`uportal-portlet-parent\` / \`org.sonatype.oss:oss-parent\`.
- **New: Send Pre-Release Notice to Community** — added before Testing (matches the uPortal RELEASE.md ordering).
- **Close and Release from Nexus Staging Repository** → rewritten as **Verify and Publish from Central Publisher Portal**: manual \`curl POST\` to the staging API, search-for-open-staging fallback, portal UI review/publish, and a POM-packaging note citing the uPortal WAR validation issue.
- **References**: drop dead OSSRH guide; add Central Portal guide + OSSRH Staging API guide + maven-release-plugin.

## Test plan

- [ ] Render the updated page in the docs site preview and check formatting
- [ ] Confirm every link resolves (central.sonatype.org, central.sonatype.com, keyserver.ubuntu.com, maven-release-plugin)
- [ ] Spot-check the \`curl\` commands against the OSSRH Staging API docs
- [ ] Dry-run the audit step (\`grep -RIn --include=pom.xml -E 'oss\.sonatype\.org|sonatype-nexus-staging' .\`) on a portlet repo to confirm it flags the expected lines

## Background

Derived from the March/April 2026 uPortal 5.x release effort, where we hit and fixed:

- Sonatype OSSRH URL sunset (\`uPortal-Project/uPortal@f882671ff1\`)
- Central Portal validation rejecting the WAR submodule due to hardcoded \`packaging 'jar'\` in the Gradle \`uploadArchives\` block (\`uPortal-Project/uPortal@640a35de75\`) — same class of bug to watch for in Maven projects with mixed packaging.