### PR TITLE
docs(release): flag <developers> as a required POM element

### DIFF
--- a/manuals/en/uportal5-manual/developer/maven-release-process.md
+++ b/manuals/en/uportal5-manual/developer/maven-release-process.md
@@ -63,6 +63,36 @@ grep -RIn --include=pom.xml -E 'oss\.sonatype\.org|sonatype-nexus-staging' .
 
 If any stale OSSRH URLs appear, override them with a `<distributionManagement>` block in the component's top-level `pom.xml` so the inherited values are shadowed. Long-term, release an updated parent POM with the new URLs so every descendant picks them up automatically.
 
+### Verify required POM metadata
+
+The Central Publisher Portal rejects deployments missing certain POM elements. In addition to the URLs above, every published POM must declare a `<developers>` element. Missing developers info returns:
+
+```
+HTTP 400
+Deployment reached an unexpected status: Failed
+pkg:maven/<groupId>/<artifactId>@<version>
+- Developers information is missing
+```
+
+**Audit before releasing:**
+
+```sh
+grep -rl --include=pom.xml '<developers>' . || echo "MISSING: no <developers> block in any POM"
+```
+
+For components inheriting from `uportal-portlet-parent`, the block is inherited automatically (version `44+`). For components on older parent versions, on a different parent (e.g. `spring-boot-starter-parent`), or publishing the parent itself, declare the block explicitly in the top-level `pom.xml`:
+
+```xml
+<developers>
+    <developer>
+        <organization>uPortal Developers</organization>
+        <organizationUrl>https://github.com/uPortal-Project/uPortal/blob/master/docs/COMMITTERS.md</organizationUrl>
+    </developer>
+</developers>
+```
+
+Pointing at the `COMMITTERS.md` in the main `uPortal` repo keeps this stable across all ecosystem releases; individual contributors come and go, the committers list is the durable reference.
+
 ## Which Repo?
 
 We encourage performing releases directly from a clone of the official repository rather than a fork to avoid extra steps.


### PR DESCRIPTION
## Summary

Add a new audit step to the Maven release guide's pre-release checks: every published POM must declare a `<developers>` element or Central Portal validation rejects the deployment.

## Why

Discovered during the April 2026 `resource-server 1.5.1` release attempt. `mvn release:prepare` and `release:perform` succeeded, GPG signing succeeded, the OSSRH staging upload authenticated — and then the manual Central Portal upload returned:

```
HTTP 400
{"error":"Failed to process request: Deployment reached an unexpected status: Failed
pkg:maven/org.jasig.resourceserver/resource-server-content@1.5.1
- Developers information is missing
...(same for every submodule)"}
```

Neither `resource-server` nor its parent `uportal-portlet-parent:43` declared a `<developers>` element. The fix landed in two PRs:

- `uPortal-Project/resource-server#325` — per-project override
- `uPortal-Project/uportal-portlet-parent#6` — ecosystem-wide fix so future portlets inherit it automatically

This PR captures the same learning in the canonical release doc so the next person running `release:prepare` can audit for it before wasting the ceremony.

## Changes to `manuals/en/uportal5-manual/developer/maven-release-process.md`

New subsection `### Verify required POM metadata` under the existing `## Setup` block, next to the distribution-URLs audit. Includes:

- Explanation of the HTTP 400 failure mode
- A `grep` audit snippet
- The recommended `<developers>` block pointing at the uPortal `COMMITTERS.md`
- Guidance on when the block is inherited vs when it must be declared explicitly (old parent, different parent, or the parent POM itself)

## Test plan

- [ ] Verify the page renders correctly in the docs preview
- [ ] Confirm the `COMMITTERS.md` link resolves
- [ ] Dry-run the audit `grep` on a portlet repo to confirm it flags missing blocks