### PR TITLE
chore(deps): bump cspell to ~10.0.0 and add Français to dict

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/iron
+          node-version: lts/jod
       - run: npm install
       - run: npm test

--- a/cspell.json
+++ b/cspell.json
@@ -65,6 +65,7 @@
         "fontawesome",
         "FOSS",
         "FOSSY",
+        "Français",
         "freefair",
         "genkey",
         "Goodfellow",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@cspell/dict-fr-fr": "~2.3.0",
-    "cspell": "~8.13.0",
+    "cspell": "~10.0.0",
     "remark-cli": "^11.0.0",
     "remark-preset-lint-consistent": "^5.0.0",
     "remark-preset-lint-recommended": "^6.0.0",


### PR DESCRIPTION
## Summary

- supersedes renovate's open cspell bumps (#92 to ~10.0, #86 to ~8.19) by combining the version bump with the two small follow-ups it needs
- **cspell.json** — cspell 8.18+ stopped silently accepting non-ASCII tokens that aren't in a loaded dictionary; the bare word `Français` in the language picker on `README.md` / `manuals/README.md` now fails spell-check. Added to the words list.
- **.github/workflows/main.yml** — cspell v10 requires Node ≥ 22.18.0; bumped CI Node from `lts/iron` (20) to `lts/jod` (22).
- goes straight to v10 since #86 (minor) and #92 (major) fail spell-check the same way; staying on a maintained line keeps future renovate noise low

After this merges, close #92 and #86 as superseded.

## Test plan

- [x] `npm install` clean on Node 22
- [x] `npm test` passes locally
- [x] CI green on this PR (with the `lts/jod` bump)