### PR TITLE
ci: limit GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: main
 on:
   - pull_request
   - push
+permissions:
+  contents: read
 jobs:
   main:
     name: Spell Check and Lint Check


### PR DESCRIPTION
## Summary

- closes the CodeQL "Workflow does not contain permissions" alert on \`.github/workflows/main.yml\`
- adds a workflow-level \`permissions: contents: read\` block, the minimum the job needs (it only checks out the repo and runs cspell + remark-lint)
- without this, jobs in the workflow inherit the repository default GITHUB_TOKEN scopes (write access to actions, contents, issues, pull-requests, packages, pages, deployments, statuses, etc.)

## Test plan

- [ ] CI green on this PR (workflow re-runs against itself with the new permissions, so a failure here would surface immediately)

## Note

This PR touches `.github/workflows/`, which the local `gh` CLI can't merge without the `workflow` OAuth scope. Merge via the GitHub UI.